### PR TITLE
[Bugfix] camera always on

### DIFF
--- a/src/containers/AddFriendModal.js
+++ b/src/containers/AddFriendModal.js
@@ -20,6 +20,7 @@ class AddFriendModal extends PureComponent {
     this.refreshKeyInfoInterval = null
     this.state = {
       friendReqId: '',
+      modalClosable: isIOS()
     };
     this.onFriendIdChange = this.onFriendIdChange.bind(this);
     this.openCamera       = this.openCamera.bind(this);
@@ -69,7 +70,7 @@ class AddFriendModal extends PureComponent {
             onModalClose,
             modal: { currentModal },
             modalInput:{ friend } } = this.props
-    const { friendReqId } = this.state
+    const { friendReqId, modalClosable } = this.state
 
     let onSubmitAndClose = function() {
       friend.addFriendAction(friendReqId)
@@ -109,8 +110,12 @@ class AddFriendModal extends PureComponent {
                     <div className={styles['submodal-qr-code-scanner']}>
                       <QrReader
                         delay={300}
-                        onError={(err) => console.error(err)}
+                        onError={(err) => {
+                          console.error(err)
+                          this.setState({modalClosable:true})
+                        }}
                         onScan={this.onScanned}
+                        onLoad={()=>this.setState({modalClosable:true})}
                         className={styles['submodal-qr-code-scanner']}
                       />
                       <div className={styles['submodal-qr-code-text']}>
@@ -137,7 +142,13 @@ class AddFriendModal extends PureComponent {
                     defaultMessage="Add"
                   />
                 </button>
-                <button className={styles['submodal-signin-cancel']} onClick={onModalClose}>
+                <button className={styles['submodal-signin-cancel']}
+                  onClick={() => {
+                    // js would throw error if we close modal when qr-reader is not loaded yet
+                    // which would keep camera rolling.
+                    modalClosable && onModalClose();
+                  }}
+                >
                   <FormattedMessage
                     id="first-popup-modal.action1"
                     defaultMessage="Cancel"


### PR DESCRIPTION
這張票應該算是 react-qr-reader 的 bug，
它在抓不到 `<QRReader />` 時沒有做 error handling，導致 js exception
所以關閉 camera 的 function 就沒跑到，導致相機關不掉。

我現在的做法是，避免 `<QRReader />` 在被抓到之前就消失，所以使用者會有 ~1s 的時間不能關掉 modal。